### PR TITLE
[BUGFIX] Change select field for detect metdata

### DIFF
--- a/Classes/Hooks/FileReferenceRequiredFieldsHook.php
+++ b/Classes/Hooks/FileReferenceRequiredFieldsHook.php
@@ -195,7 +195,7 @@ class FileReferenceRequiredFieldsHook
             ['*'],
             'sys_file_metadata',
             [
-                'uid' => $id,
+                'file' => $id,
             ]
         );
         $metaData = $result->fetchAssociative();


### PR DESCRIPTION
With an older database it can happen that the UIDs of sys_file and sys_file_metadata are not in sync. Therefore you should check for the `file` field