### PR TITLE
[BUGFIX] continue handling instead of return

### DIFF
--- a/Classes/Hooks/FileReferenceRequiredFieldsHook.php
+++ b/Classes/Hooks/FileReferenceRequiredFieldsHook.php
@@ -100,7 +100,7 @@ class FileReferenceRequiredFieldsHook
 
             // Skip required field check
             if ($requiredColumns === []) {
-                return;
+                continue;
             }
 
             $sysFileMetaData = $this->detectSysFileMetadataRecord($fileId);


### PR DESCRIPTION
If multiple reference fields are inside a dataset and one triggers the requiredColumns empty, all others should be checked, too. In this case, a return if requiredColumns is empty, will lead to false database columns if working with virtual fields.

Better way is using a continue for deciding other fields executing as their behaviour, so virtual field handling can work as expected and set the field in metadata and remove from reference, where the field is not in database.