### PR TITLE
[BUGFIX] Set class for metadata edit button via setClasses

### DIFF
--- a/Classes/EventListener/FileListActionsEvent.php
+++ b/Classes/EventListener/FileListActionsEvent.php
@@ -39,7 +39,7 @@ final class FileListActionsEvent
         if ($missing) {
             $actionItems = $event->getActionItems();
             if (array_key_exists('metadata', $actionItems)) {
-                $actionItems['metadata'] = str_replace('btn-default', 'btn-danger', $actionItems['metadata']);
+                $actionItems['metadata']?->setClasses('required-attributes-missing');
                 $event->setActionItems($actionItems);
             }
             $languageService = $this->languageServiceFactory->createFromUserPreferences($GLOBALS['BE_USER'] ?? null);


### PR DESCRIPTION
Due to changes in the rendering order of the FileList class the event now carries the button classes (e.g. LinkButton) instead of the already rendered html string. So accessing and replacing the rendered html of the button is no option anymore. At least not at this point.

Adding the custom specific css class will add the css class to the rendered button html element but will not have any effect on the way the button is displayed. This is a temporary hotfix and the original idea/functionality will be readded in the future.