### PR TITLE
[BUGFIX] Correct Vendor namespace

### DIFF
--- a/Classes/Template/Components/Buttons/LinkButton.php
+++ b/Classes/Template/Components/Buttons/LinkButton.php
@@ -13,7 +13,7 @@
  * The TYPO3 project - inspiring people to share!
  */
 
-namespace WebVision\FileRequiredAttributes\Template\Components\Buttons;
+namespace FGTCLB\FileRequiredAttributes\Template\Components\Buttons;
 
 /**
  * LinkButton

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,15 +1,20 @@
 <?php
 
+use FGTCLB\FileRequiredAttributes\Form\Element\FileRequiredValueElement;
+use FGTCLB\FileRequiredAttributes\Hooks\FileReferenceRequiredFieldsHook;
+use FGTCLB\FileRequiredAttributes\Template\Components\Buttons\LinkButton;
+use TYPO3\CMS\Backend\Template\Components\Buttons\LinkButton as Typo3LinkButton;
+
 (static function (): void {
     // Datahandler Hooks
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][]
-        = \FGTCLB\FileRequiredAttributes\Hooks\FileReferenceRequiredFieldsHook::class;
+        = FileReferenceRequiredFieldsHook::class;
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1682603901292] = [
         'nodeName' => 'fileRequiredAttributeShow',
         'priority' => 40,
-        'class' => \FGTCLB\FileRequiredAttributes\Form\Element\FileRequiredValueElement::class,
+        'class' => FileRequiredValueElement::class,
     ];
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][TYPO3\CMS\Backend\Template\Components\Buttons\LinkButton::class] = [
-        'className' => WebVision\FileRequiredAttributes\Template\Components\Buttons\LinkButton::class
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][Typo3LinkButton::class] = [
+        'className' => LinkButton::class
     ];
 })();


### PR DESCRIPTION
While implementing the LinkButton override, a wrong vendor was used.

Correct the respective class and xclass implementation.